### PR TITLE
Feat: API데이터를 불러오고 advice message 화면에 출력하기

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,11 @@
 import './style/tailwind.css';
+import AdviceCard from './components/adviceCard';
 
 function App() {
   return (
-    <div className="App"></div>
+    <div className="App bg-[#1F2632] w-full h-screen flex items-center justify-center">
+      <AdviceCard />
+    </div>
   );
 }
 

--- a/src/components/adviceCard.js
+++ b/src/components/adviceCard.js
@@ -1,4 +1,22 @@
+import { useState, useEffect } from "react";
+
 export default function AdviceCard() {
+    // API 주소
+    const ADVICE_API = "https://api.adviceslip.com/advice";
+
+    // 데이터 state
+    const [adviceData, setAdviceData] = useState([]);
+
+    // api 데이터 가져오기
+    useEffect(() => {
+        fetch(ADVICE_API)
+            .then(res => res.json())
+            .then(data => {
+                console.log(data.slip)
+                setAdviceData(data.slip);
+            })
+    }, []);
+
 
     return (
         <section className="w-1/3 max-h-96 min-h-60 p-8 bg-[#4E5D73] rounded-lg text-center relative">

--- a/src/components/adviceCard.js
+++ b/src/components/adviceCard.js
@@ -1,0 +1,9 @@
+export default function AdviceCard() {
+
+    return (
+        <section className="w-1/3 max-h-96 min-h-60 p-8 bg-[#4E5D73] rounded-lg text-center relative">
+            <h2 className="text-[#52FFA8] text-sm font-medium -tracking-tighter">ADVICE #1</h2>
+            <div className='text-lg font-semibold -tracking-tighter my-8 text-white break-keep'>테스트용 텍스트 입니다.</div>
+        </section>
+    )
+}

--- a/src/components/adviceCard.js
+++ b/src/components/adviceCard.js
@@ -20,8 +20,8 @@ export default function AdviceCard() {
 
     return (
         <section className="w-1/3 max-h-96 min-h-60 p-8 bg-[#4E5D73] rounded-lg text-center relative">
-            <h2 className="text-[#52FFA8] text-sm font-medium -tracking-tighter">ADVICE #1</h2>
-            <div className='text-lg font-semibold -tracking-tighter my-8 text-white break-keep'>테스트용 텍스트 입니다.</div>
+            <h2 className="text-[#52FFA8] text-sm font-medium -tracking-tighter">ADVICE #{adviceData.id}</h2>
+            <div className='text-lg font-semibold -tracking-tighter my-8 text-white break-keep'>"{adviceData.advice}"</div>
         </section>
     )
 }


### PR DESCRIPTION
### **What?**

- API를 불러오고 card 박스에 advice message를 보여줍니다.

### **Why?**

- API는 새로고침 될 때마다 새로운 램덤 advice message를 렌더링 시킵니다.
- 추후에 버튼을 클릭할 때마다 새로운 메세지를 보여줄 수 있게 하기 위한 준비 단계입니다.

### **How?**

- adviceCard component를 만들어  advice message를 보여줄  card UI를 구현하였습니다.
- fetch를 이용해 API 데이터를 가져왔습니다.
- 데이터를 동적으로 사용할 것이기 때문에 useState를 사용하여 화면에 출력하였습니다.

### **issue**

- 데이터가 업데이트 될 때마다 무한으로 렌더링되는 문제가 있었습니다.

### **solution**

- useEffect의 deps에 빈 배열을 주어 렌더링 후 1번만 실행되게 하였습니다.
